### PR TITLE
Fix a grammatical error.

### DIFF
--- a/docs/broadcast-control-old/interrupt.mdx
+++ b/docs/broadcast-control-old/interrupt.mdx
@@ -70,7 +70,7 @@ async def group_message_handler(
 
         await inc.wait(waiter)
         # highlight-end
-        await app.sendGroupMessage(group, MessageChain.creat([
+        await app.sendGroupMessage(group, MessageChain.create([
             Plain("执行完毕.")
         ]))
 


### PR DESCRIPTION
Fix a grammatical error in line 73 "await app.sendGroupMessage(group, MessageChain.creat([" which causes "AttributeError: type object 'MessageChain' has no attribute 'creat'" error.